### PR TITLE
fix: add explicit schema for token payload

### DIFF
--- a/example/app.ts
+++ b/example/app.ts
@@ -21,10 +21,15 @@ export default await AppContainer.create({
               ability.can('manage', 'all');
             }
           },
-          loginCredentialsSchema: z.object({
-            password: z.string().min(1),
-            username: z.string().min(1)
-          }),
+          schemas: {
+            loginCredentials: z.object({
+              password: z.string().min(1),
+              username: z.string().min(1)
+            }),
+            tokenPayload: z.object({
+              isAdmin: z.boolean()
+            })
+          },
           userQuery: async ({ username }) => {
             if (username !== 'admin') {
               return null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ export { CurrentUser } from './decorators/current-user.decorator.js';
 export { RouteAccess } from './decorators/route-access.decorator.js';
 export { ValidationSchema } from './decorators/validation-schema.decorator.js';
 export { DataTransferObject } from './mixins/data-transfer-object.mixin.js';
-export type { AuthModuleOptions, UserQuery, UserQueryResult } from './modules/auth/auth.config.js';
+export type { AuthModuleOptions } from './modules/auth/auth.config.js';
 export { AuthModule } from './modules/auth/auth.module.js';
 export { ConfigService } from './modules/config/config.service.js';
 export { CryptoService } from './modules/crypto/crypto.service.js';

--- a/src/modules/auth/__tests__/auth.module.spec.ts
+++ b/src/modules/auth/__tests__/auth.module.spec.ts
@@ -43,7 +43,7 @@ describe('AuthModule', () => {
   let jwtStrategy: JwtStrategy;
 
   let defineAbility: Mock<DefineAbility>;
-  let userQuery: Mock<UserQuery>;
+  let userQuery: Mock<UserQuery<{ password: string; username: string }, { username: string }>>;
 
   const loginCredentials = {
     password: 'password',
@@ -62,10 +62,15 @@ describe('AuthModule', () => {
       imports: [
         AuthModule.forRoot({
           defineAbility,
-          loginCredentialsSchema: z.object({
-            password: z.string(),
-            username: z.string()
-          }),
+          schemas: {
+            loginCredentials: z.object({
+              password: z.string(),
+              username: z.string()
+            }),
+            tokenPayload: z.object({
+              username: z.string()
+            })
+          },
           userQuery: userQuery
         }),
         ConfigModule.forRoot({

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -19,7 +19,7 @@ import { LoginCredentialsDto } from './dto/login-credentials.dto.js';
 import { JwtAuthGuard } from './guards/jwt-auth.guard.js';
 import { JwtStrategy } from './strategies/jwt.strategy.js';
 
-import type { AuthModuleOptions, BaseLoginCredentialsSchema, UserQuery } from './auth.config.js';
+import type { AuthModuleOptions, BaseLoginCredentialsSchema } from './auth.config.js';
 
 @Module({
   controllers: [AuthController],
@@ -58,22 +58,22 @@ import type { AuthModuleOptions, BaseLoginCredentialsSchema, UserQuery } from '.
 export class AuthModule extends ConfigurableAuthModule implements OnModuleInit {
   private readonly loginCredentialsSchema: BaseLoginCredentialsSchema;
 
-  constructor(@Inject(AUTH_MODULE_OPTIONS_TOKEN) { loginCredentialsSchema }: AuthModuleOptions) {
+  constructor(@Inject(AUTH_MODULE_OPTIONS_TOKEN) { schemas }: AuthModuleOptions) {
     super();
-    this.loginCredentialsSchema = loginCredentialsSchema;
+    this.loginCredentialsSchema = schemas.loginCredentials;
   }
 
   static forRoot<
     TLoginCredentialsSchema extends BaseLoginCredentialsSchema,
-    TUserQuery extends UserQuery<z.TypeOf<TLoginCredentialsSchema>>
-  >(options: AuthModuleOptions<TLoginCredentialsSchema, TUserQuery>): DynamicModule {
+    TPayloadSchema extends z.ZodType<{ [key: string]: unknown }>
+  >(options: AuthModuleOptions<TLoginCredentialsSchema, TPayloadSchema>): DynamicModule {
     return super.forRoot(options);
   }
   static forRootAsync<
     TLoginCredentialsSchema extends BaseLoginCredentialsSchema,
-    TUserQuery extends UserQuery<z.TypeOf<TLoginCredentialsSchema>>
+    TPayloadSchema extends z.ZodType<{ [key: string]: unknown }>
   >(
-    options: ConfigurableModuleAsyncOptions<AuthModuleOptions<TLoginCredentialsSchema, TUserQuery>, 'create'>
+    options: ConfigurableModuleAsyncOptions<AuthModuleOptions<TLoginCredentialsSchema, TPayloadSchema>, 'create'>
   ): DynamicModule {
     return super.forRootAsync(options);
   }


### PR DESCRIPTION
Inferring the type is impossible due to a known issue not planned to be fixed in TypeScript. This solution adds more boilerplate, but makes sure that library consumers don't access non-existent properties during the authentication process.