### PR TITLE
test: increase test timeout to 20s for slow github runner

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -26,6 +26,7 @@ export default defineConfig({
     globals: true,
     include: ['{example,src}/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     setupFiles: [path.resolve(import.meta.dirname, 'src/testing/setup.ts')],
+    testTimeout: 20_000,
     watch: false
   }
 });


### PR DESCRIPTION
It seems we now have too many tests to run on the GitHub runner with the default max timeout of 5s