### PR TITLE
fix: increase throttle limit from 5 to 50

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -16,7 +16,7 @@ export class AuthController {
   @HttpCode(HttpStatus.OK)
   @Post('login')
   @RouteAccess('public')
-  @Throttle({ long: { limit: 5 } })
+  @Throttle({ long: { limit: 50 } })
   async login(@Body() credentials: LoginCredentialsDto): Promise<LoginResponseBody> {
     return this.authService.login(credentials);
   }


### PR DESCRIPTION
At the Douglas, users will share an IP address, so a limit of 5 per minute could pose problems. 

In ODC, only passwords where is would take an estimated 10,000,000,000 guesses or more to brute force the password are acceptable. Therefore, with this new setup, it would take an average of 380.5 years to brute force the weakest password, up from 76.1 years with the default app config.