### PR TITLE
feat: allow using Zod schema directly to parse request body

### DIFF
--- a/example/app.test.ts
+++ b/example/app.test.ts
@@ -6,8 +6,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, vi } from 'vitest';
 import { e2e } from '../src/testing/index.js';
 import app from './app.js';
 
-import type { CreateCatDto } from './cats/dto/create-cat.dto.js';
-import type { Cat } from './cats/schemas/cat.schema.js';
+import type { $Cat, $CreateCatData } from './cats/schemas/cat.schema.js';
 
 vi.unmock('@prisma/client');
 
@@ -102,7 +101,7 @@ e2e(app, ({ api }) => {
 
   describe('/cats', (it) => {
     let accessToken: string;
-    let createdCat: Cat;
+    let createdCat: $Cat;
 
     beforeEach(async () => {
       const response = await api.post('/auth/login').send({ password: 'password', username: 'admin' });
@@ -126,13 +125,13 @@ e2e(app, ({ api }) => {
         .send({
           age: 1,
           name: 'Winston'
-        } satisfies CreateCatDto);
+        } satisfies $CreateCatData);
       expect(response.status).toBe(201);
       expect(response.body).toMatchObject({
         _id: expect.any(String),
         age: expect.any(Number),
         name: expect.any(String)
-      } satisfies Cat);
+      } satisfies $Cat);
       createdCat = response.body;
     });
 

--- a/example/cats/__tests__/cats.service.test.ts
+++ b/example/cats/__tests__/cats.service.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { PRISMA_CLIENT_TOKEN } from '../../../src/modules/prisma/prisma.config.js';
 import { CatsService } from '../cats.service.js';
 
-import type { Cat } from '../schemas/cat.schema.js';
+import type { $Cat } from '../schemas/cat.schema.js';
 
 describe('CatsService', () => {
   let catsService: CatsService;
@@ -29,7 +29,7 @@ describe('CatsService', () => {
 
   describe('create', () => {
     it('should create a new cat successfully', async () => {
-      const mockCat: Omit<Cat, '_id'> = {
+      const mockCat: Omit<$Cat, '_id'> = {
         age: 3,
         name: 'Whiskers'
       };
@@ -46,7 +46,7 @@ describe('CatsService', () => {
     });
 
     it('should throw InternalServerErrorException when creation fails', async () => {
-      const mockCat: Omit<Cat, '_id'> = {
+      const mockCat: Omit<$Cat, '_id'> = {
         age: 3,
         name: 'Whiskers'
       };
@@ -57,7 +57,7 @@ describe('CatsService', () => {
 
   describe('findAll', () => {
     it('should return all cats successfully', async () => {
-      const mockCats: Cat[] = [
+      const mockCats: $Cat[] = [
         { _id: '1', age: 3, name: 'Whiskers' },
         { _id: '2', age: 2, name: 'Mittens' }
       ];

--- a/example/cats/cats.controller.ts
+++ b/example/cats/cats.controller.ts
@@ -3,9 +3,7 @@ import { ApiOperation } from '@nestjs/swagger';
 
 import { RouteAccess } from '../../src/index.js';
 import { CatsService } from './cats.service.js';
-import { CreateCatDto } from './dto/create-cat.dto.js';
-
-import type { Cat } from './schemas/cat.schema.js';
+import { $Cat, $CreateCatData } from './schemas/cat.schema.js';
 
 @Controller('cats')
 export class CatsController {
@@ -14,14 +12,14 @@ export class CatsController {
   @ApiOperation({ summary: 'Create Cat' })
   @Post()
   @RouteAccess({ action: 'create', subject: 'Cat' })
-  async create(@Body() createCatDto: CreateCatDto): Promise<Cat> {
-    return this.catsService.create(createCatDto);
+  async create(@Body() data: $CreateCatData): Promise<$Cat> {
+    return this.catsService.create(data);
   }
 
   @ApiOperation({ summary: 'Get All Cats' })
   @Get()
   @RouteAccess({ action: 'read', subject: 'Cat' })
-  async findAll(): Promise<Cat[]> {
+  async findAll(): Promise<$Cat[]> {
     return this.catsService.findAll();
   }
 }

--- a/example/cats/cats.service.ts
+++ b/example/cats/cats.service.ts
@@ -5,13 +5,13 @@ import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { InjectPrismaClient } from '../../src/index.js';
 
 import type { PrismaClientLike } from '../../src/index.js';
-import type { Cat } from './schemas/cat.schema.js';
+import type { $Cat } from './schemas/cat.schema.js';
 
 @Injectable()
 export class CatsService {
   constructor(@InjectPrismaClient() private readonly prismaClient: PrismaClientLike) {}
 
-  async create(cat: Omit<Cat, '_id'>): Promise<Cat> {
+  async create(cat: Omit<$Cat, '_id'>): Promise<$Cat> {
     const id = crypto.randomUUID();
     const result = await this.prismaClient.$runCommandRaw({
       insert: 'Cat',
@@ -23,11 +23,11 @@ export class CatsService {
     return { ...cat, _id: id };
   }
 
-  async findAll(): Promise<Cat[]> {
+  async findAll(): Promise<$Cat[]> {
     const result = (await this.prismaClient.$runCommandRaw({
       find: 'Cat',
       batchSize: 1000
-    })) as { cursor: { firstBatch: Cat[]; id: string }; ok: number };
+    })) as { cursor: { firstBatch: $Cat[]; id: string }; ok: number };
     if (result.ok !== 1) {
       throw new InternalServerErrorException('Failed to find cats');
     }

--- a/example/cats/dto/create-cat.dto.ts
+++ b/example/cats/dto/create-cat.dto.ts
@@ -1,4 +1,0 @@
-import { DataTransferObject } from '../../../src/index.js';
-import { $Cat } from '../schemas/cat.schema.js';
-
-export class CreateCatDto extends DataTransferObject($Cat.omit({ _id: true })) {}

--- a/example/cats/schemas/cat.schema.ts
+++ b/example/cats/schemas/cat.schema.ts
@@ -1,8 +1,11 @@
 import { z } from 'zod/v4';
 
-export type Cat = z.infer<typeof $Cat>;
+export type $Cat = z.infer<typeof $Cat>;
 export const $Cat = z.object({
-  _id: z.string().uuid(),
+  _id: z.uuid(),
   age: z.number(),
   name: z.string()
 });
+
+export type $CreateCatData = z.infer<typeof $CreateCatData>;
+export const $CreateCatData = $Cat.omit({ _id: true });

--- a/example/pages/index.tsx
+++ b/example/pages/index.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
 import type { JSX } from 'react';
 
-import type { Cat } from '../cats/schemas/cat.schema.js';
+import type { $Cat } from '../cats/schemas/cat.schema.js';
 
 type CatsProps = {
-  cats: Cat[];
+  cats: $Cat[];
 };
 
 const Cats: React.FC<CatsProps> = ({ cats }): JSX.Element => {

--- a/src/modules/mail/mail.module.ts
+++ b/src/modules/mail/mail.module.ts
@@ -1,8 +1,9 @@
-import { Module } from '@nestjs/common';
+import { Global, Module } from '@nestjs/common';
 
 import { ConfigurableMailModule } from './mail.config.js';
 import { MailService } from './mail.service.js';
 
+@Global()
 @Module({
   exports: [MailService],
   providers: [MailService]

--- a/src/pipes/validation.pipe.ts
+++ b/src/pipes/validation.pipe.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import type { ArgumentMetadata, PipeTransform } from '@nestjs/common';
+import { z } from 'zod/v4';
 
 import { getValidationSchema, parseRequestBody } from '../utils/validation.utils.js';
 
@@ -12,7 +13,12 @@ export class ValidationPipe implements PipeTransform {
       throw new Error('Metatype must be defined!');
     }
 
-    const schema = getValidationSchema(metatype);
+    let schema: z.ZodType;
+    if (metatype instanceof z.ZodType) {
+      schema = metatype;
+    } else {
+      schema = getValidationSchema(metatype);
+    }
 
     return parseRequestBody(value, schema);
   }


### PR DESCRIPTION
Previously, validating request bodies required wrapping Zod schemas in classes. This is the only approach I have seen and is due to TypeScript's decorator metadata limitations, which requires the parameter to be a runtime value, not just a type. This introduced a huge amount of unnecessary boilerplate and is very annoying.

However, using our `$Schema` naming convention, we can define both the Zod schema and the corresponding output type using the same identifier. Thus, when used as a type, it represents the output type of the schema, while when used as a value it is the schema. For example:

```ts
import { z } from 'zod/v4';

export type $Cat = z.infer<typeof $Cat>;
export const $Cat = z.object({
  _id: z.uuid(),
  age: z.number(),
  name: z.string()
});

export type $CreateCatData = z.infer<typeof $CreateCatData>;
export const $CreateCatData = $Cat.omit({ _id: true });

 ```
 
 ```ts
 import { Body, Controller, Get, Post } from '@nestjs/common';
import { ApiOperation } from '@nestjs/swagger';

import { RouteAccess } from '../../src/index.js';
import { CatsService } from './cats.service.js';
import { $Cat, $CreateCatData } from './schemas/cat.schema.js';

@Controller('cats')
export class CatsController {
  constructor(private readonly catsService: CatsService) {}

  @ApiOperation({ summary: 'Create Cat' })
  @Post()
  @RouteAccess({ action: 'create', subject: 'Cat' })
  async create(@Body() data: $CreateCatData): Promise<$Cat> {
    return this.catsService.create(data);
  }

  @ApiOperation({ summary: 'Get All Cats' })
  @Get()
  @RouteAccess({ action: 'read', subject: 'Cat' })
  async findAll(): Promise<$Cat[]> {
    return this.catsService.findAll();
  }
}
```