### PR TITLE
 allow specifying multiple env files @joshunrau

### DIFF
--- a/src/cli/libnest.js
+++ b/src/cli/libnest.js
@@ -36,8 +36,8 @@ program.requiredOption('-c, --config-file <path>', 'path to the config file', (f
   return parseResult(resolveAbsoluteImportPath(filename, process.cwd()));
 });
 
-program.option('-e, --env-file <path>', 'path to an env file to source', (filename) => {
-  return parseResult(resolveAbsolutePath(filename, process.cwd()));
+program.option('-e, --env-file <paths...>', 'path to env file(s) to source', (filename, previous) => {
+  return (previous ?? []).concat(parseResult(resolveAbsolutePath(filename, process.cwd())));
 });
 
 program.addOption(
@@ -52,10 +52,9 @@ program.command('dev', 'run application in development mode', {
 });
 
 program.hook('preSubcommand', (command) => {
-  const envFile = command.getOptionValue('envFile');
-  if (envFile) {
+  command.getOptionValue('envFile')?.forEach((/** @type {string} */ envFile) => {
     process.loadEnvFile(envFile);
-  }
+  });
   process.env.LIBNEST_CONFIG_FILEPATH = command.getOptionValue('configFile');
   process.env.LIBNEST_JAVASCRIPT_RUNTIME = command.getOptionValue('runtime');
 });

--- a/src/utils/env.utils.ts
+++ b/src/utils/env.utils.ts
@@ -14,7 +14,9 @@ export function parseEnv<TSchema extends BaseEnvSchema = BaseEnvSchema>(schema: 
   );
   if (envConfigResult.isErr()) {
     throw new RuntimeException('Failed to parse environment config', {
-      cause: envConfigResult.error
+      details: {
+        issues: envConfigResult.error.details.issues
+      }
     });
   }
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return


### PR DESCRIPTION
for example, `libnest dev -e .env .env.development`