### PR TITLE
fix annoying ts errors preventing build but that pass linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,13 @@
     "neverthrow": "^8.2.0",
     "reflect-metadata": "~0.1.13",
     "rxjs": "^7.8.2",
+    "vitest": "4.x",
     "zod": "^3.25.x"
+  },
+  "peerDependenciesMeta": {
+    "vite": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@douglasneuroinformatics/libjs": "^3.1.0",

--- a/src/testing/mocks/prisma.model.mock.ts
+++ b/src/testing/mocks/prisma.model.mock.ts
@@ -1,23 +1,23 @@
 import { vi } from 'vitest';
 
 export class MockPrismaModel {
-  aggregate = vi.fn();
-  aggregateRaw = vi.fn();
-  count = vi.fn();
-  create = vi.fn();
-  createMany = vi.fn();
-  delete = vi.fn();
-  deleteMany = vi.fn();
-  exists = vi.fn();
-  fields = vi.fn();
-  findFirst = vi.fn();
-  findFirstOrThrow = vi.fn();
-  findMany = vi.fn();
-  findRaw = vi.fn();
-  findUnique = vi.fn();
-  findUniqueOrThrow = vi.fn();
-  groupBy = vi.fn();
-  update = vi.fn();
-  updateMany = vi.fn();
-  upsert = vi.fn();
+  aggregate = vi.fn<(...args: any[]) => any>();
+  aggregateRaw = vi.fn<(...args: any[]) => any>();
+  count = vi.fn<(...args: any[]) => any>();
+  create = vi.fn<(...args: any[]) => any>();
+  createMany = vi.fn<(...args: any[]) => any>();
+  delete = vi.fn<(...args: any[]) => any>();
+  deleteMany = vi.fn<(...args: any[]) => any>();
+  exists = vi.fn<(...args: any[]) => any>();
+  fields = vi.fn<(...args: any[]) => any>();
+  findFirst = vi.fn<(...args: any[]) => any>();
+  findFirstOrThrow = vi.fn<(...args: any[]) => any>();
+  findMany = vi.fn<(...args: any[]) => any>();
+  findRaw = vi.fn<(...args: any[]) => any>();
+  findUnique = vi.fn<(...args: any[]) => any>();
+  findUniqueOrThrow = vi.fn<(...args: any[]) => any>();
+  groupBy = vi.fn<(...args: any[]) => any>();
+  update = vi.fn<(...args: any[]) => any>();
+  updateMany = vi.fn<(...args: any[]) => any>();
+  upsert = vi.fn<(...args: any[]) => any>();
 }

--- a/src/testing/mocks/prisma.module.mock.ts
+++ b/src/testing/mocks/prisma.module.mock.ts
@@ -10,7 +10,7 @@ export const PrismaClient = vi.fn(() => {
 
 export const Prisma = {
   defineExtension: vi.fn((arg) => arg as unknown),
-  getExtensionContext: vi.fn(),
+  getExtensionContext: vi.fn<(...args: any[]) => any>(),
   ModelName: {
     Cat: 'Cat'
   }


### PR DESCRIPTION
These fun errors again:

The inferred type of 'Prisma' cannot be named without a reference to '.pnpm/@vitest+spy@4.0.17/node_modules/@vitest/spy'. This is likely not portable. A type annotation is necessary.