### PR TITLE
fix(meta): define build banner globals as writable

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,6 +21,8 @@ jobs:
           node-version-file: '.nvmrc'
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
+      - name: Generate Prisma
+        run: pnpm prisma:generate
       - name: Lint
         run: pnpm run lint
       - name: Test
@@ -30,4 +32,3 @@ jobs:
         with:
           directory: ./coverage/
           token: ${{ secrets.CODECOV_TOKEN }}
-

--- a/src/meta/__tests__/globals-banner.test.ts
+++ b/src/meta/__tests__/globals-banner.test.ts
@@ -11,7 +11,7 @@ import { GLOBALS_BANNER } from '../build.js';
 const execFileAsync = promisify(execFile);
 
 /**
- * The banner that `@prisma/client` >= 6.19.3 prepends to its ESM runtime, which esbuild inlines into
+ * The banner that `@prisma/client` >= 6.19.0 prepends to its ESM runtime, which esbuild inlines into
  * the application bundle verbatim. The assignment to `globalThis` is the part that matters.
  */
 const DEPENDENCY_BANNER = [
@@ -40,14 +40,14 @@ describe('GLOBALS_BANNER', () => {
 
   it('should not leave a bundled dependency unable to assign to globalThis', { timeout: 30000 }, async () => {
     const esbuild = await import('esbuild');
-    const srcdir = path.join(outdir, 'src');
-    await fs.promises.mkdir(srcdir, { recursive: true });
+    const sourceDir = path.join(outdir, 'src');
+    await fs.promises.mkdir(sourceDir, { recursive: true });
     await fs.promises.writeFile(
-      path.join(srcdir, 'dependency.js'),
+      path.join(sourceDir, 'dependency.js'),
       `${DEPENDENCY_BANNER}\nexport const value = 'ok';\n`
     );
     await fs.promises.writeFile(
-      path.join(srcdir, 'entry.js'),
+      path.join(sourceDir, 'entry.js'),
       "import { value } from './dependency.js';\nconsole.log(value);\n"
     );
 
@@ -55,7 +55,7 @@ describe('GLOBALS_BANNER', () => {
     await esbuild.build({
       banner: { js: GLOBALS_BANNER },
       bundle: true,
-      entryPoints: [path.join(srcdir, 'entry.js')],
+      entryPoints: [path.join(sourceDir, 'entry.js')],
       format: 'esm',
       outfile,
       platform: 'node'

--- a/src/meta/__tests__/globals-banner.test.ts
+++ b/src/meta/__tests__/globals-banner.test.ts
@@ -1,0 +1,68 @@
+import { execFile } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { promisify } from 'node:util';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { GLOBALS_BANNER } from '../build.js';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * The banner that `@prisma/client` >= 6.19.3 prepends to its ESM runtime, which esbuild inlines into
+ * the application bundle verbatim. The assignment to `globalThis` is the part that matters.
+ */
+const DEPENDENCY_BANNER = [
+  'import * as __banner_node_path from "node:path";',
+  'import * as __banner_node_url from "node:url";',
+  'const __filename = __banner_node_url.fileURLToPath(import.meta.url);',
+  "globalThis['__dirname'] = __banner_node_path.dirname(__filename);"
+].join('\n');
+
+describe('GLOBALS_BANNER', () => {
+  let outdir: string;
+
+  beforeAll(async () => {
+    outdir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'globals-banner-'));
+  });
+
+  afterAll(async () => {
+    await fs.promises.rm(outdir, { force: true, recursive: true });
+  });
+
+  it('should define the commonjs globals', () => {
+    expect(GLOBALS_BANNER).toContain('__dirname');
+    expect(GLOBALS_BANNER).toContain('__filename');
+    expect(GLOBALS_BANNER).toContain('require');
+  });
+
+  it('should not leave a bundled dependency unable to assign to globalThis', { timeout: 30000 }, async () => {
+    const esbuild = await import('esbuild');
+    const srcdir = path.join(outdir, 'src');
+    await fs.promises.mkdir(srcdir, { recursive: true });
+    await fs.promises.writeFile(
+      path.join(srcdir, 'dependency.js'),
+      `${DEPENDENCY_BANNER}\nexport const value = 'ok';\n`
+    );
+    await fs.promises.writeFile(
+      path.join(srcdir, 'entry.js'),
+      "import { value } from './dependency.js';\nconsole.log(value);\n"
+    );
+
+    const outfile = path.join(outdir, 'server.js');
+    await esbuild.build({
+      banner: { js: GLOBALS_BANNER },
+      bundle: true,
+      entryPoints: [path.join(srcdir, 'entry.js')],
+      format: 'esm',
+      outfile,
+      platform: 'node'
+    });
+
+    // a non-writable property makes the inlined assignment throw, so the bundle dies before this resolves
+    const { stdout } = await execFileAsync(process.execPath, [outfile]);
+    expect(stdout.trim()).toBe('ok');
+  });
+});

--- a/src/meta/build.ts
+++ b/src/meta/build.ts
@@ -19,7 +19,7 @@ import type { UserConfigOptions } from '../user-config.js';
  * dependencies expect to exist at runtime.
  *
  * These are defined `writable: true` deliberately. Some dependencies ship an esbuild-style banner of
- * their own that assigns to `globalThis['__dirname']` (`@prisma/client` >= 6.19.3 does). Once inlined
+ * their own that assigns to `globalThis['__dirname']` (`@prisma/client` >= 6.19.0 does). Once inlined
  * into this bundle, that assignment runs in module scope, where a non-writable property makes it throw
  * `TypeError: Cannot assign to read only property` instead of failing silently, killing the process
  * before the app bootstraps.

--- a/src/meta/build.ts
+++ b/src/meta/build.ts
@@ -14,6 +14,19 @@ import { swcPlugin } from './plugins/swc.js';
 
 import type { UserConfigOptions } from '../user-config.js';
 
+/**
+ * The banner prepended to the production bundle, which backfills the CommonJS globals that some
+ * dependencies expect to exist at runtime.
+ *
+ * These are defined `writable: true` deliberately. Some dependencies ship an esbuild-style banner of
+ * their own that assigns to `globalThis['__dirname']` (`@prisma/client` >= 6.19.3 does). Once inlined
+ * into this bundle, that assignment runs in module scope, where a non-writable property makes it throw
+ * `TypeError: Cannot assign to read only property` instead of failing silently, killing the process
+ * before the app bootstraps.
+ */
+export const GLOBALS_BANNER =
+  "Object.defineProperties(globalThis, { __dirname: { value: import.meta.dirname, writable: true }, __filename: { value: import.meta.filename, writable: true }, require: { value: (await import('module')).createRequire(import.meta.url), writable: true } });";
+
 export function buildProd({
   configFile,
   verbose
@@ -63,7 +76,7 @@ export function buildProd({
 
       await esbuild.build({
         banner: {
-          js: "Object.defineProperties(globalThis, { __dirname: { value: import.meta.dirname, writable: false }, __filename: { value: import.meta.filename, writable: false }, require: { value: (await import('module')).createRequire(import.meta.url), writable: false } });"
+          js: GLOBALS_BANNER
         },
         bundle: true,
         define,


### PR DESCRIPTION
## Summary

Fixes the crash reported in #77. The production build banner in `src/meta/build.ts` defined `__dirname`, `__filename`, and `require` on `globalThis` as **non-writable**. Some dependencies ship an esbuild-style banner of their own that *assigns* to `globalThis['__dirname']`. Once esbuild inlines such a runtime into our bundle, that assignment executes in module scope — where a non-writable property throws instead of failing silently:

```
TypeError: Cannot assign to read only property '__dirname' of object '#<Object>'
```

The process dies before the app bootstraps. Flipping the three properties to `writable: true` makes those later assignments harmless overwrites — in Prisma's case with an identical value, since both resolve to the dirname of the executing bundle.

## Why we hadn't seen this

`@prisma/client` changed its ESM runtime banner from a module-local `const __dirname` to `globalThis['__dirname'] = …`. libnest pins **6.9.0**, which still uses the harmless module-local form, so no build in this repo or in our apps has ever inlined the assigning banner. The bug is latent in every libnest release until an app's import graph pulls in a newer Prisma runtime — which is exactly how it surfaced downstream, on OpenDataCapture `main`.

One correction to the issue: the assignment landed in **6.19.0**, not 6.19.3. Verified against the published tarballs — 6.19.0, 6.19.1, 6.19.2, 6.19.3 and current 7.x all carry it; 6.9.0 does not. 6.19.3 is just where the reporter happened to hit it.

Nothing shielded us: `src/meta/plugins/prisma.ts` only appends a `PRISMA_QUERY_ENGINE_LIBRARY` define and copies the engine binary — the runtime `.mjs` is not in the `external` list, so it does get inlined.

## Scope

Only `src/meta/build.ts` is affected. The `writable: false` at `src/meta/dev.ts:24` that the issue also points at is unrelated — it applies to user-supplied `config.globals`, not `__dirname`/`__filename`, and dev mode doesn't bundle, so Prisma's runtime loads as its own module where the assignment succeeds. Left as-is.

In practice only `__dirname` is implicated: Prisma's `__filename` and `require` are module-scoped `const`s that esbuild renames on inline. All three are flipped anyway, since Prisma is the instance at hand and not the only possible one.

## Testing

Adds `src/meta/__tests__/globals-banner.test.ts`, which bundles a dependency carrying the upstream banner and boots the result in a subprocess. Confirmed non-vacuous — reverting the fix makes it fail with the exact `TypeError` from the issue.

`npm run lint` clean; full suite passes except `example/app.test.ts`, which fails identically on a clean tree here (local mongod port conflict, exit code 48) and is unrelated to this change.

Closes #77
